### PR TITLE
Add OAuth flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,28 @@ import { Navbar } from 'reactstrap';
 
 import { Footer } from './components/Footer';
 import { WebMapContainer } from './containers/WebMapContainer';
+import { IdentityContainer } from './containers/IdentityContainer';
 
 import './App.css';
 
-class App extends React.Component<object, object> {
+const portalUrl = 'https://www.arcgis.com/sharing';
+const appId = 'y4Lx1l6456Mbf85z';
+
+interface AppProps {}
+interface AppState {
+  credential?: __esri.Credential;
+}
+
+class App extends React.Component<AppProps, AppState> {
+  constructor(props: AppProps) {
+    super(props);
+    this.state = {};
+    this.handleLoginChange = this.handleLoginChange.bind(this);
+  }
+
+  handleLoginChange(credential: __esri.Credential) {
+    this.setState({credential});
+  }
 
   render() {
     return (
@@ -14,13 +32,21 @@ class App extends React.Component<object, object> {
         <div className="row">
           <Navbar>
             Cadasta
+            <IdentityContainer
+              credential={this.state.credential}
+              portalUrl={portalUrl}
+              appId={appId}
+              handleLoginChange={this.handleLoginChange}
+            />
           </Navbar>
         </div>
         <div className="row h-100">
           {/* TODO: This should probably be a route (the home route) */}
-          <WebMapContainer
-            portalId="459eb07ed2544fd4b655b87dca7abf8c"
-          />
+          {this.state.credential && 
+            <WebMapContainer
+              portalId="459eb07ed2544fd4b655b87dca7abf8c"
+            />
+          }
         </div>
         <div className="row">
           <Footer />

--- a/src/components/Identity.tsx
+++ b/src/components/Identity.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+interface IdentityProps {
+  credential?: __esri.Credential;
+  handleLogin: () => void;
+  handleLogout: () => void;
+}
+
+export const Identity = (props: IdentityProps) => {
+  if (props.credential) {
+    return (
+      <span>
+        Logged in as {props.credential.userId}
+        <button onClick={props.handleLogout}>
+          Logout
+        </button>
+      </span>
+    );
+  } else {
+    return (
+      <button onClick={props.handleLogin}>
+        Login
+      </button>
+    );
+  }
+};

--- a/src/containers/IdentityContainer.tsx
+++ b/src/containers/IdentityContainer.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+import { esriPromise } from 'react-arcgis';
+
+import { Identity } from '../components/Identity';
+
+export interface IdentityManagerEvent {
+  credential: __esri.Credential;
+}
+interface IdentityComponentProps {
+  credential?: __esri.Credential;
+  portalUrl: string;
+  appId: string;
+  handleLoginChange: (credential?: __esri.Credential) => void;
+}
+interface IdentityComponentState {}
+
+export class IdentityContainer extends React.Component<IdentityComponentProps, IdentityComponentState> {
+  IdentityManager: __esri.IdentityManager;
+
+  constructor(props: IdentityComponentProps) {
+    super(props);
+    this.handleLogin = this.handleLogin.bind(this);
+    this.handleLogout = this.handleLogout.bind(this);
+  }
+
+  componentDidMount() {
+    esriPromise([
+      'esri/identity/OAuthInfo',
+      'esri/identity/IdentityManager'
+    ]).then(([OAuthInfo, IdentityManager]) => {
+      this.IdentityManager = IdentityManager;
+
+      IdentityManager.on('credential-create', (e: IdentityManagerEvent) => this.props.handleLoginChange(e.credential));
+      IdentityManager.on('credentials-destroy', () => this.props.handleLoginChange());
+
+      const info = new OAuthInfo({
+        appId: this.props.appId,
+        popup: false
+      });
+      IdentityManager.registerOAuthInfos([info]);
+      IdentityManager.checkSignInStatus(this.props.portalUrl);
+    });
+  }
+
+  handleLogout() {
+    if (this.IdentityManager) {
+      this.IdentityManager.destroyCredentials();
+    }
+  }
+
+  handleLogin() {
+    if (this.IdentityManager) {
+      this.IdentityManager.getCredential(this.props.portalUrl);
+    }
+  }
+
+  render() {
+    return (
+      <Identity
+        credential={this.props.credential}
+        handleLogout={this.handleLogout}
+        handleLogin={this.handleLogin}
+      />
+    );
+  }
+}


### PR DESCRIPTION
Adding OAuth flow using [`IdentityManager`](https://developers.arcgis.com/javascript/latest/api-reference/esri-identity-IdentityManager.html).

The workflow is similar to [my work using the ArcGIS API](https://github.com/Cadasta/cadasta-esri/pull/22):

1. We check if the user has an active session.
    - If yes, the map and a logout button are rendered
    - If no, the login button is rendered
2. The user *clicks login* and is redirected to an ESRI sign-in page. Upon successful login, the browser redirects back to the app and we go back to step one.
3. The user *clicks logout*, the current credentials are destroyed and the page is reloaded. We go back to step one. 

--- 

There's no nice way to import modules from the ArcGIS JS API that are not supported in `react-arcgis`. So I had to use `esriPromise` from [`esri-loader`](https://github.com/Esri/esri-loader) to load the modules when initialising the app.